### PR TITLE
Improve parity with the Korean version 

### DIFF
--- a/en/component-guide.md
+++ b/en/component-guide.md
@@ -50,6 +50,8 @@ Specifies the NAT instance as a route gateway. The packets delivered to the NAT 
 
 
 ## MS-SQL Instance
+
+### Allow Security Group TCP Port 3389 (RDP)
 After instance is created, access the instance by using Remote Desktop Protocol (RDP). 
 To that end, an instance must be associated with a floating IP and TCP port 3389 (RDP) must be allowed for security group. 
 
@@ -69,9 +71,10 @@ Execute Microsoft SQL Server Management Studio and associate to an object under 
 
 ![mssqlinstance_03_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_03_201812_en.png)
 
-1. Select an object, right-click it, and choose **Attributes**. 
-2. On **Server Attributes** , click **Security**. 
-3. Change the **Server Certification** type into **SQL Server and Windows Certification Mode**.
+1. Right-click on an object.
+2. Choose **Properties** on the menu. 
+3. On **Server Properties** , click **Security**. 
+4. Change the **Server Certification** type into **SQL Server and Windows Certification Mode**.
 
 ※ To apply the changed SQL certification mode, restart Microsoft SQL. 
 
@@ -86,9 +89,10 @@ Execute SQL Server configuration manager as below.
 ![mssqlinstance_04_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_04_201812_en.png)
 
 1. Click **Protocol for MSSQLSERVER** below **SQL Server Network Configuration** from menu on the left. 
-2. Click **TCP/IP** for **Protocol Name** and right click it. When the menu shows, select **Attributes**.  
-3. Select the **IP Address** tab. 
-4. Select **IP ALL** on the list and change the port number to another.  
+2. Right-click **TCP/IP** among protocol names.
+3. When the menu shows up, select **Properties**.  
+4. Select the **IP Address** tab. 
+5. Select **IP ALL** on the list and change the port number to another.  
 
 ※ To apply the changed service port, restart Microsoft SQL. 
 
@@ -106,9 +110,9 @@ Microsoft SQL data/log files (MDF/LDF) and backup files are recommended to be ap
 Go to **Compute > Instance > Block Storage** and create a block storage.  
 **Universal SSD** is a recommended volume type for improved performance.
 
-After a block storage is created, select the storage and click **Association Management** and associate it to an instance.  
-
 ![mssqlinstance_06_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_06_201812_en.png)
+
+After a block storage is created, select the storage and click **Association Management** and associate it to an instance.  
 
 <br/>
 
@@ -130,7 +134,7 @@ Click unassigned disk and right-click it. Select **New Simple Volume** and proce
 
 <br/>
 
-In the **Database Setting** of **Server Attributes** of Microsoft SQL Server Management Studio,  change **Default Database Location** into the directory where the volume has been created. 
+In the **Database Setting** of **Server Properties** of Microsoft SQL Server Management Studio,  change **Default Database Location** into the directory where the volume has been created. 
 
 ![mssqlinstance_09_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_09_201812_en.png)
 
@@ -140,7 +144,7 @@ In the **Database Setting** of **Server Attributes** of Microsoft SQL Server Man
 Change of Microsoft SQL settings sometimes requires a restart of the service.  
 To apply changed settings, restart Microsoft SQL.   
 
-From SQL Server Configuration Manager, go to **SQL Server Configuration Manager (local) > SQL Server Service > SQL Server (MSSQLSERVER)** and right click it. When the menu shows, click **Restart** to restart the service. 
+From SQL Server Configuration Manager, go to **SQL Server Configuration Manager (local) > SQL Server Service > SQL Server (MSSQLSERVER)** and right click it. When the menu shows up, click **Restart** to restart the service. 
 
 ![mssqlinstance_10_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_10_201812_en.png)
 
@@ -153,7 +157,7 @@ Go to **SQL Server Configuration Manager (local) > SQL Server** in the SQL Serve
 
 When the service start mode for **SQL SERVER (MSSSQLSERVER) and SQL Server Agent (MSSQLSERVER)** are not **automatic**, do the followings: 
 
-1. Click the service and right-click it. Select **Attributes** on the menu. 
+1. Click the service and right-click it. Select **Properties** on the menu. 
 2. Change **Service** on **General > Start Mode** to **Automatic**.
 
 > [Note]
@@ -265,8 +269,8 @@ Directory and file description of MySQL are as below:
 
 > For detailed release status of MySQL Instance, please refer to [Instance Release Notes](/Compute/Compute/en/release-notes/).
 
-
 ## PostgreSQL Instance
+
 ### How to start/stop PostgreSQL
 
 ```
@@ -284,7 +288,6 @@ shell> sudo systemctl restart postgresql-13
 
 In the beginning after creating an image, log in as shown below.
 <br>
-
 ```
 #Switch account to postgres and log in
 shell> sudo su - postgres
@@ -297,7 +300,6 @@ shell> psql
 
 The image port provided is 5432, the default PostgreSQL port. Port change is recommended for security purposes.
 <br>
-
 ```
 shell> vi /var/lib/pgsql/13/data/postgresql.conf
 
@@ -324,7 +326,6 @@ shell> psql -p[changed port number]
 
 The default timezone recorded in the server log is set to UTC. It is recommended to change it to match the local time of the SYSTEM.
 <br>
-
 ```
 shell> vi /var/lib/pgsql/13/data/postgresql.conf
 
@@ -356,7 +357,6 @@ postgres=# SHOW log_timezone;
 
 Since all users are provided with CREATE and USAGE permissions for public schema by default, users who can log in to the DB can create objects in public schema. It is recommended to cancel the permissions so that no users can create objects in public schema.
 <br>
-
 ```
 #Log in to postgresql
 
@@ -372,7 +372,6 @@ postgres=# REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 
 To allow logins other than local host, you need to change the listen_addresses variable and client authentication setup file.
 <br>
-
 ```
 shell> vi /var/lib/pgsql/13/data/postgresql.conf
 
@@ -420,6 +419,7 @@ PostgreSQL directory and file description is as follows:
 | LOG            | PostgreSQL log file path - /var/lib/pgsql/{version}/data/log/\*.log |
 
 ## CUBRID Instance
+
 ### How to Start/Stop the CUBRID service
 
 You can start or stop the CUBRID service as follows by logging in with the “cubrid” Linux account.
@@ -802,9 +802,12 @@ The default accounts provided by Tibero are as follows.
 * OUTLN: Performs tasks such as storing related hints so that the same SQL can always be executed with the same plan.
 * TIBERO/TIBERO1: An example user with the DBA privilege.
 
+
 ## JEUS Instance
 
-The images provided by default include CentOS 7.8 with JEUS8Fix1 (Domain Administrator Server 2022.03.22) and CentOS 7.8 with JEUS8Fix1 (Managed Server 2022.03.22). To install Domain Administrator Server, use CentOS 7.8 with JEUS8Fix1 (Domain Administrator Server 2022.03.22) image. To install Managed Server, use the CentOS 7.8 with JEUS8Fix1 (Managed Server 2022.03.22) image.
+The images provided by default include CentOS 7.8 with JEUS8Fix1 (Domain Administrator Server 2022.03.22) and CentOS 7.8 with JEUS8Fix1 (Managed Server 2022.03.22).
+To install Domain Administrator Server, use CentOS 7.8 with JEUS8Fix1 (Domain Administrator Server 2022.03.22) image.
+To install Managed Server, use the CentOS 7.8 with JEUS8Fix1 (Managed Server 2022.03.22) image.
 
 JEUS is installed in `~/apps/jeus8`.
 
@@ -851,11 +854,11 @@ Run WebAdmin as follows:
 3. If you connect to in http://{floatingIP}:9736/webadmin in a web browser, you can see the WebAdmin screen.
 
 
+
 ## WebtoB Instance
 
 The image provided by default is CentOS 7.8 with WebtoB5Fix4 (2022.03.22).
 WebtoB is installed in `~/apps/webtob`.
-
 
 ### Check the Startup
 

--- a/en/component-guide.md
+++ b/en/component-guide.md
@@ -52,134 +52,134 @@ Specifies the NAT instance as a route gateway. The packets delivered to the NAT 
 ## MS-SQL Instance
 
 ### Allow Security Group TCP Port 3389 (RDP)
-After instance is created, access the instance by using Remote Desktop Protocol (RDP). 
-To that end, an instance must be associated with a floating IP and TCP port 3389 (RDP) must be allowed for security group. 
+After instance is created, access the instance by using Remote Desktop Protocol (RDP).
+To that end, an instance must be associated with a floating IP and TCP port 3389 (RDP) must be allowed for security group.
 
 ![mssqlinstance_02_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_02_201812_en.png)
 
-Click **+ Check Password** to check password by using key pair configured along with instance creation. 
-Click **Associate** and download .rdp file, to access the instance by using the acquired password. 
+Click **+ Check Password** to check password by using key pair configured along with instance creation.
+Click **Associate** and download .rdp file, to access the instance by using the acquired password.
 
-### Initial Settings after Microsoft SQL Image is Created  
+### Initial Settings after Microsoft SQL Image is Created
 
-#### 1. Set SQL Certification Mode  
+#### 1. Set SQL Certification Mode
 
-The default certification mode of the server is set with"**Windows Certification Mode**". 
-To use Microsoft SQL database account, the mode must be changed to SQL Certification Mode. 
+The default certification mode of the server is set with"**Windows Certification Mode**".
+To use Microsoft SQL database account, the mode must be changed to SQL Certification Mode.
 
-Execute Microsoft SQL Server Management Studio and associate to an object under the instance name. 
+Execute Microsoft SQL Server Management Studio and associate to an object under the instance name.
 
 ![mssqlinstance_03_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_03_201812_en.png)
 
 1. Right-click on an object.
-2. Choose **Properties** on the menu. 
-3. On **Server Properties** , click **Security**. 
+2. Choose **Properties** on the menu.
+3. On **Server Properties** , click **Security**.
 4. Change the **Server Certification** type into **SQL Server and Windows Certification Mode**.
 
-※ To apply the changed SQL certification mode, restart Microsoft SQL. 
+※ To apply the changed SQL certification mode, restart Microsoft SQL.
 
-#### 2. Change Microsoft SQL Service Port 
+#### 2. Change Microsoft SQL Service Port
 
-The default port 1433 for Microsoft SQL is widely known and might serve as a security vulnerability.   
-A change is recommended to another port. 
-※ For Express, no default port is specified. 
+The default port 1433 for Microsoft SQL is widely known and might serve as a security vulnerability.
+A change is recommended to another port.
+※ For Express, no default port is specified.
 
-Execute SQL Server configuration manager as below. 
+Execute SQL Server configuration manager as below.
 
 ![mssqlinstance_04_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_04_201812_en.png)
 
-1. Click **Protocol for MSSQLSERVER** below **SQL Server Network Configuration** from menu on the left. 
+1. Click **Protocol for MSSQLSERVER** below **SQL Server Network Configuration** from menu on the left.
 2. Right-click **TCP/IP** among protocol names.
-3. When the menu shows up, select **Properties**.  
-4. Select the **IP Address** tab. 
-5. Select **IP ALL** on the list and change the port number to another.  
+3. When the menu shows up, select **Properties**.
+4. Select the **IP Address** tab.
+5. Select **IP ALL** on the list and change the port number to another.
 
-※ To apply the changed service port, restart Microsoft SQL. 
+※ To apply the changed service port, restart Microsoft SQL.
 
-#### 3. Allow External Access to Microsoft SQL Database 
+#### 3. Allow External Access to Microsoft SQL Database
 
-To allow external access to Microsoft SQL Database, go to the **Security Group** tab of **Network > VPC** and add Microsoft SQL service port for security rules. 
-Also, register Microsoft SQL service port (default port: 1433) to allow access, as well as remote IP.  
+To allow external access to Microsoft SQL Database, go to the **Security Group** tab of **Network > VPC** and add Microsoft SQL service port for security rules.
+Also, register Microsoft SQL service port (default port: 1433) to allow access, as well as remote IP.
 
-### Data Volume Assignment  
+### Data Volume Assignment
 
-Microsoft SQL data/log files (MDF/LDF) and backup files are recommended to be applied with separate block storages.  
+Microsoft SQL data/log files (MDF/LDF) and backup files are recommended to be applied with separate block storages.
 
 ![mssqlinstance_05_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_05_201812_en.png)
 
-Go to **Compute > Instance > Block Storage** and create a block storage.  
+Go to **Compute > Instance > Block Storage** and create a block storage.
 **Universal SSD** is a recommended volume type for improved performance.
 
 ![mssqlinstance_06_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_06_201812_en.png)
 
-After a block storage is created, select the storage and click **Association Management** and associate it to an instance.  
+After a block storage is created, select the storage and click **Association Management** and associate it to an instance.
 
 <br/>
 
-Access instance with RDP and execute **Computer Management**, and go to **Storage>Disk Management**. 
+Access instance with RDP and execute **Computer Management**, and go to **Storage>Disk Management**.
 
 ![mssqlinstance_07_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_07_201812_en.png)
 
-You can find the associated block storage is detected. To use it, initialize disk first. 
-1. Right-click the **Disk 1** block and click **Initialize Disk**. 
-2. Select a partition type and click **OK**. 
+You can find the associated block storage is detected. To use it, initialize disk first.
+1. Right-click the **Disk 1** block and click **Initialize Disk**.
+2. Select a partition type and click **OK**.
 
 <br/>
 
-After initialization is completed, create disk volume. 
+After initialization is completed, create disk volume.
 
 ![mssqlinstance_08_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_08_201812_en.png)
 
-Click unassigned disk and right-click it. Select **New Simple Volume** and proceed with wizard for new simple volume. 
+Click unassigned disk and right-click it. Select **New Simple Volume** and proceed with wizard for new simple volume.
 
 <br/>
 
-In the **Database Setting** of **Server Properties** of Microsoft SQL Server Management Studio,  change **Default Database Location** into the directory where the volume has been created. 
+In the **Database Setting** of **Server Properties** of Microsoft SQL Server Management Studio,  change **Default Database Location** into the directory where the volume has been created.
 
 ![mssqlinstance_09_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_09_201812_en.png)
 
-※ To apply the changed default database location, restart Microsoft SQL. 
+※ To apply the changed default database location, restart Microsoft SQL.
 
-### Restart Microsoft SQL 
-Change of Microsoft SQL settings sometimes requires a restart of the service.  
-To apply changed settings, restart Microsoft SQL.   
+### Restart Microsoft SQL
+Change of Microsoft SQL settings sometimes requires a restart of the service.
+To apply changed settings, restart Microsoft SQL.
 
-From SQL Server Configuration Manager, go to **SQL Server Configuration Manager (local) > SQL Server Service > SQL Server (MSSQLSERVER)** and right click it. When the menu shows up, click **Restart** to restart the service. 
+From SQL Server Configuration Manager, go to **SQL Server Configuration Manager (local) > SQL Server Service > SQL Server (MSSQLSERVER)** and right click it. When the menu shows up, click **Restart** to restart the service.
 
 ![mssqlinstance_10_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_10_201812_en.png)
 
 ### Check/Set Automatic Microsoft SQL  Service Execution
-Check if Microsoft SQL is set for automatic start with OS running.  
+Check if Microsoft SQL is set for automatic start with OS running.
 
-Go to **SQL Server Configuration Manager (local) > SQL Server** in the SQL Server Configuration Manager to find **Start Mode**.  
+Go to **SQL Server Configuration Manager (local) > SQL Server** in the SQL Server Configuration Manager to find **Start Mode**.
 
 ![mssqlinstance_11_201812](https://static.toastoven.net/prod_ms_sql/mssqlinstance_11_201812_en.png)
 
-When the service start mode for **SQL SERVER (MSSSQLSERVER) and SQL Server Agent (MSSQLSERVER)** are not **automatic**, do the followings: 
+When the service start mode for **SQL SERVER (MSSSQLSERVER) and SQL Server Agent (MSSQLSERVER)** are not **automatic**, do the followings:
 
-1. Click the service and right-click it. Select **Properties** on the menu. 
+1. Click the service and right-click it. Select **Properties** on the menu.
 2. Change **Service** on **General > Start Mode** to **Automatic**.
 
 > [Note]
 > For the release status of Microsoft SQL Instance, see [Instance Release Note](/Compute/Compute/ko/release-notes/).
 
 ## MySQL Instance
-### Starting/Stopping MySQL 
+### Starting/Stopping MySQL
 
 ```
-#Start mysql Service 
+#Start mysql Service
 shell> service mysqld start
 
-#Stop mysql Service 
+#Stop mysql Service
 shell> service mysqld stop
 
-#Restart mysql Service 
+#Restart mysql Service
 shell> service mysqld restart
 ```
 
-### Connecting to MySQL 
+### Connecting to MySQL
 
-For initial connection, connect to MySQL with default user name. 
+For initial connection, connect to MySQL with default user name.
 
 ```
 shell> mysql -uroot
@@ -189,9 +189,9 @@ shell> mysql -uroot
 
 #### 1\. Setting Password
 
-There's no password on root user on initial installation. Therefore, it is required to set password as soon as possible.  
+There's no password on root user on initial installation. Therefore, it is required to set password as soon as possible.
 
-* Set Password for MySQL Version 5.6  
+* Set Password for MySQL Version 5.6
 
 ```
 SET PASSWORD [FOR user] = password_option
@@ -199,7 +199,7 @@ SET PASSWORD [FOR user] = password_option
 mysql> set password=password('password');
 ```
 
-* Set Password for MySQL Version 5.7  
+* Set Password for MySQL Version 5.7
 
 ```
 ALTER USER USER() IDENTIFIED BY 'auth_string';
@@ -214,21 +214,21 @@ Default MySQL validate_password_policy is as below:
 
 #### 2\. Changing Port Number
 
-The default MySQL port number is 3306. It is recommended to change the port number for security reasons. 
+The default MySQL port number is 3306. It is recommended to change the port number for security reasons.
 
 ```
 shell> vi /etc/my.cnf
 
 
-# Specify a port to use in the my.cnf file. 
+# Specify a port to use in the my.cnf file.
 
-port = Port name to use 
-
-
-# Save vi editor Save editor 
+port = Port name to use
 
 
-# Restart mysql service  
+# Save vi editor Save editor
+
+
+# Restart mysql service
 
 
 shell> service mysqld restart
@@ -240,9 +240,9 @@ shell> service mysqld restart
 shell> mysql -uroot -P[changed port number]
 ```
 
-### Description of my.cnf 
+### Description of my.cnf
 
-The default path of my.cnf is /etc/my.cnf, and NHN Cloud recommended variables are set as below: 
+The default path of my.cnf is /etc/my.cnf, and NHN Cloud recommended variables are set as below:
 
 | Name | Description |
 | --- | --- |
@@ -255,9 +255,9 @@ The default path of my.cnf is /etc/my.cnf, and NHN Cloud recommended variables a
 | slow\_query\_log | Enable the slow\_query log option. Queries taking more than 10 seconds in accordance with long_query_time will be logged to the slow_query_log. |
 | sysdate-is-now | For sysdate, SQL with sysdate() used for replication results in discrepant time between Master and Slave, so sysdate() and now() functions will behave the same. |
 
-### Description of MySQL Directory 
+### Description of MySQL Directory
 
-Directory and file description of MySQL are as below: 
+Directory and file description of MySQL are as below:
 
 | Name | Description |
 | --- | --- |
@@ -426,18 +426,18 @@ You can start or stop the CUBRID service as follows by logging in with the “cu
 ```
 # Start the CUBRID service/server
 shell> sudo su - cubrid
-shell> cubrid service start 
+shell> cubrid service start
 shell> cubrid server start demodb
 
 # Stop the CUBRID service/server
 shell> sudo su - cubrid
 shell> cubrid server stop demodb
-shell> cubrid service stop 
+shell> cubrid service stop
 
 # Restart the CUBRID service/server
 shell> sudo su - cubrid
 shell> cubrid server restart demodb
-shell> cubrid service restart 
+shell> cubrid service restart
 
 # Start/stop/restart the CUBRID broker
 shell> sudo su - cubrid

--- a/en/component-guide.md
+++ b/en/component-guide.md
@@ -64,7 +64,7 @@ Click **Associate** and download .rdp file, to access the instance by using the 
 
 #### 1. Set SQL Certification Mode
 
-The default certification mode of the server is set with"**Windows Certification Mode**".
+The default certification mode of the server is set with "**Windows Certification Mode**".
 To use Microsoft SQL database account, the mode must be changed to SQL Certification Mode.
 
 Execute Microsoft SQL Server Management Studio and associate to an object under the instance name.

--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,9 +1,5 @@
 ## Compute > Instance > Console Guide
 
-<!-- Video guide is not provided in the translated document -->
-
-<!-- Dummy comment for a video link -->
-
 ## Create Instances
 
 You can create instances either by using the settings below or by using instance templates. To create instances using instance templates, select **Use instance template** from the Create Instance page. To learn how to create instance templates, see [Instance Template Console Guide](/Compute/Instance%20Template/en/console-guide/).
@@ -18,6 +14,7 @@ The available instance flavors vary depending on the image you choose, so we rec
 | -------------------------------- | ------------- | ------------ |
 | Linux <br>CentOS, Ubuntu, Debian, Rocky | 20GB or more  | 1GB or more  |
 | Windows                          | 50GB or more  | 2GB or more  |
+
 
 ### Availability Zone 
 
@@ -283,6 +280,8 @@ Route commands
 * Delete : route delete "Destination" mask "Destination subnet" "gateway" metric "Metric value" if "Interface number"
 * Option : -p (specify as persistent route)
 
+
+
 Description
 
 
@@ -297,7 +296,7 @@ Example 1 - Restricting external communication for particular interfaces
 * You can restrict an interface from communicating externally by using the route change command to change its route metric or by leaving the default gateway field blank when configuring fixed IP settings.
 * How to Modify Metrics
     * Increase interface metric value
-  
+
             $ route change 0.0.0.0 mask 0.0.0.0 172.16.5.1 metric 10 if 14 -p
 
 ![이미지1](http://static.toastoven.net/prod_instance/windows_route2.png)
@@ -318,6 +317,7 @@ Example 2 - Setting routes for a particular address range
 
 ![이미지1](http://static.toastoven.net/prod_instance/windows_route6.png)
 
+
 Example 3 - Removing a particular route 
 
 * Use the route delete command to remove specified routes. 
@@ -325,6 +325,7 @@ Example 3 - Removing a particular route
         $ route delete 172.16.0.0 mask 255.255.0.0 172.16.5.1
 
 ![이미지1](http://static.toastoven.net/prod_instance/windows_route7.png)
+
 
 ## Appendix 3. Change System Locale
 
@@ -344,6 +345,7 @@ System locale in NHN Cloud Windows instances can be changed as follows.
 
 5. Restart the system to apply the changes. 
 ![이미지1](http://static.toastoven.net/prod_instance/win_locale5.png)
+
 
 ## Appendix 4. Restarting Instances for Hypervisor Maintenance 
 NHN Cloud updates hypervisor software on a regular basis to enhance the security and stability of infrastructure services that we provide.
@@ -377,6 +379,7 @@ If there is no way to do so without impacting your service, please contact NHN C
 **5. Wait until the instance status turns green and the [! Restart] button disappers.**
 
 If the status does not change or the **! Restart** button is not disabled, try refreshing the page.
+
 
 You cannot operate or modify the instance while a restart is underway.
 If an instance restart does not complete successfully, the administrator will automatically be notified and you'll also be contacted by NHN Cloud.

--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -8,7 +8,7 @@ You can create instances either by using the settings below or by using instance
 
 Select the image that contains the operating system you need. You can choose between public images provided by NHN Cloud, images you've previously created, or shared images.
 
-The available instance flavors vary depending on the image you choose, so we recommended you choose an image first when creating an instance. 
+The available instance flavors vary depending on the image you choose, so we recommended you choose an image first when creating an instance.
 
 | OS                               | Block Storage          | Memory       |
 | -------------------------------- | ------------- | ------------ |
@@ -16,7 +16,7 @@ The available instance flavors vary depending on the image you choose, so we rec
 | Windows                          | 50GB or more  | 2GB or more  |
 
 
-### Availability Zone 
+### Availability Zone
 
 If an availability zone is not specified, a random zone is selected. An instance can use a block storage only if they both exist in the same availability zone. If the block storage you wish to use exists in a particular availability zone, then select that zone.
 
@@ -26,7 +26,7 @@ For more details on availability zones, see [Availability Zone in Instance Overv
 
 ### Flavor
 
-You can select various flavors depending on virtual hardware performance specifications. However, the choice of some flavors may be limited depending on the virtual hardware performance that your image requires. For more details, see [Instance Overview](./overview). 
+You can select various flavors depending on virtual hardware performance specifications. However, the choice of some flavors may be limited depending on the virtual hardware performance that your image requires. For more details, see [Instance Overview](./overview).
 
 Instance flavors can be changed in the NHN Cloud console even after instance creation, from higher to lower specs and vice versa. However, note that some flavors cannot be changed. See [Modify flavor](./console-guide/#modify-flavor) for details.
 
@@ -34,10 +34,10 @@ Instance flavors can be changed in the NHN Cloud console even after instance cre
 
 ### Block Storage Size
 
-Determines the default disk size of an instance. 
+Determines the default disk size of an instance.
 
 - The size of the default disk cannot be changed after an instance has been created. If you require more disk space, you must use additional block storages.
-- The block storage size must be at least the minimum size required by the image. 
+- The block storage size must be at least the minimum size required by the image.
 
 The default disk size varies depending on instance flavor.
 
@@ -65,7 +65,7 @@ When you create multiple instances without specifying an availability zone, each
 
 Use an existing key pair or create a new key pair. To register an existing key pair, see [Import Key Pair (Windows)](./console-guide/#import-key-pairs-windows) for Windows users, and [Import Key Pair (Mac and Linux)](./console-guide/#import-key-pairs-mac-and-linux) for Mac and Linux users.
 
-### Network 
+### Network
 
 Select a subnet defined in your VPC to connect to an instance. For each selected subnet, a network interface is created in the instance to connect to that subnet. You can change the order of selected subnets to change network interfaces, in which case the first network interface (`eth0`) will be set as the default gateway.
 
@@ -162,11 +162,11 @@ For more details on floating IP, see [VPC Overview](/Network/VPC/en/overview/).
 
 An instance's security groups can be modified regardless of the instance's status. Modified security groups are applied immediately.
 
-For more details on security groups, see [Security Group](./console-guide/#security-group) and [VPC Overview](/Network/VPC/en/overview/). 
+For more details on security groups, see [Security Group](./console-guide/#security-group) and [VPC Overview](/Network/VPC/en/overview/).
 
 ### Change Network Subnet
 
-An instance's network subnet can only be changed while the instance is stopped. When you add a subnet, a network interface that will be connected to that subnet is automatically created on your instance. If you add multiple subnets at once, the order of the newly created network interfaces on the instance is set randomly. Deleting a subnet from an instance automatically deletes the network interface that was created along with the subnet. 
+An instance's network subnet can only be changed while the instance is stopped. When you add a subnet, a network interface that will be connected to that subnet is automatically created on your instance. If you add multiple subnets at once, the order of the newly created network interfaces on the instance is set randomly. Deleting a subnet from an instance automatically deletes the network interface that was created along with the subnet.
 
 ### Modify Flavor
 
@@ -175,7 +175,7 @@ Instance flavors can be changed once an instance has been stopped. If an instanc
 You can only change an instance to another flavor that is compatible with its current flavor.
 
 * m2, c2, r2, t2, x1 flavor instances can be changed to m2, c2, r2, t2, x1 flavors.
-* m2, c2, r2, t2, x1 flavor instances cannot be changed to u2 flavors. 
+* m2, c2, r2, t2, x1 flavor instances cannot be changed to u2 flavors.
 * u2 flavor instances cannot be changed to other flavors once they have been created, not even to those of the same u2 flavor.
 
 When you modify flavors, instance resize and resize confirmation tasks proceed. When all tasks are completed, the VM changes its status to **Shutoff**. You can start the instance by clicking **Start Instance** in **Additional Features**.
@@ -249,7 +249,7 @@ NHN Cloud provides Windows images with English as the primary language. You may 
 5. Download and install the language pack.
 ![이미지1](http://static.toastoven.net/prod_instance/windows5.png)
 
-6. Download and install updates. 
+6. Download and install updates.
 ![이미지1](http://static.toastoven.net/prod_instance/windows6.png)
 
 7. To change to the installed language pack, double-click the selected language or select **Options**.
@@ -304,7 +304,7 @@ Example 1 - Restricting external communication for particular interfaces
 * How to Set Fixed IP
     1. Use the ipconfig /all command to view IP information.
 ![이미지1](http://static.toastoven.net/prod_instance/windows_route3.png)
-    2. Enter the corresponding IP information, leaving the default gateway field blank, in the IP Properties window. 
+    2. Enter the corresponding IP information, leaving the default gateway field blank, in the IP Properties window.
 ![이미지1](http://static.toastoven.net/prod_instance/windows_route4.png)
     3. Check the results using the route print command.
 ![이미지1](http://static.toastoven.net/prod_instance/windows_route5.png)
@@ -318,9 +318,9 @@ Example 2 - Setting routes for a particular address range
 ![이미지1](http://static.toastoven.net/prod_instance/windows_route6.png)
 
 
-Example 3 - Removing a particular route 
+Example 3 - Removing a particular route
 
-* Use the route delete command to remove specified routes. 
+* Use the route delete command to remove specified routes.
 
         $ route delete 172.16.0.0 mask 255.255.0.0 172.16.5.1
 
@@ -329,12 +329,12 @@ Example 3 - Removing a particular route
 
 ## Appendix 3. Change System Locale
 
-System locale in NHN Cloud Windows instances can be changed as follows. 
+System locale in NHN Cloud Windows instances can be changed as follows.
 
 1. Go to **Windows Key > Control Panel > Clock, Language, and Region**.
 ![이미지1](http://static.toastoven.net/prod_instance/win_locale1.png)
 
-2. Select **Region**. 
+2. Select **Region**.
 ![이미지1](http://static.toastoven.net/prod_instance/win_locale2.png)
 
 3. From the **Administrative** tab, click **Change system locale**.
@@ -343,11 +343,11 @@ System locale in NHN Cloud Windows instances can be changed as follows.
 4. Select a system locale to use.
 ![이미지1](http://static.toastoven.net/prod_instance/win_locale4.png)
 
-5. Restart the system to apply the changes. 
+5. Restart the system to apply the changes.
 ![이미지1](http://static.toastoven.net/prod_instance/win_locale5.png)
 
 
-## Appendix 4. Restarting Instances for Hypervisor Maintenance 
+## Appendix 4. Restarting Instances for Hypervisor Maintenance
 NHN Cloud updates hypervisor software on a regular basis to enhance the security and stability of infrastructure services that we provide.
 Instances running on a hypervisor that requires maintenance must be restarted and migrated to a hypervisor which has completed maintenance.
 
@@ -361,7 +361,7 @@ Go to the project where your instance requiring maintenance is located.
 
 Any instance that has the **! Restart** button before its name requires maintenance.
 Put the mouse cursor over the **! Restart** button to find maintenance schedule details.
-![Instance Maintenance Image 1](http://static.toastoven.net/prod_instance/instance_p_migration_en_1.png)    
+![Instance Maintenance Image 1](http://static.toastoven.net/prod_instance/instance_p_migration_en_1.png)
 
 **2. Deactivate or stop application programs running on an instance which requires maintenance.**
 

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,5 +1,6 @@
 ## Compute > Instance > Overview 
 
+
 An instance is a virtual server composed of virtual CPUs, memory, and default disk. You can install your services and applications on this server and use it in combination with the various services provided by NHN Cloud.
 
 ## Components  
@@ -20,7 +21,6 @@ Instance properties and usage change depending on these components. While settin
 An image is a virtual disk that contains an operating system. NHN Cloud currently supports CentOS, Debian, Ubuntu, Rocky, and Windows. For more details on the supported operating system versions, see [NHN Cloud Service Introduction](https://toast.com/service/compute/instance).
 
 All images are configured to run optimally on an instance's virtual hardware and are safe to use as they have undergone security inspection by NHN Cloud. For more details on images, see [Image Overview](/Compute/Image/en/overview/).
-
 
 ### Flavor
 
@@ -70,17 +70,12 @@ An instance must be connected to at least one network defined in the VPC in orde
 
 Instances are charged using the following criteria.
 
-
 * Instances are charged from the moment they are created.
 * Instance default disks are charged separately according to the block storage pricing policy.
 * Stopped instances are charged only for their default disk and additional block storage (if any block storage has been added).
 
 
 ## How to Access Instances 
-
-<!-- Video guide is not provided in the translated document -->
-
-<!-- Dummy comment for a video link -->
 
 ### How to Access Linux Instances 
 
@@ -147,6 +142,7 @@ Run PuTTY and select **Connection > SSH > Auth** from the **Category** on the le
 ![이미지3](http://static.toastoven.net/prod_instance/putty005-en.png)
 
 Once you register your private key, you do not have to re-register your private key file each time you access your instance if you save your access information. For details on how to save your access information, see the section below on accessing instances.
+
 
 **B. Registering a Private Key File for Authentication in pageant (PuTTY's Authentication Agent)**
 

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,11 +1,11 @@
-## Compute > Instance > Overview 
+## Compute > Instance > Overview
 
 
 An instance is a virtual server composed of virtual CPUs, memory, and default disk. You can install your services and applications on this server and use it in combination with the various services provided by NHN Cloud.
 
-## Components  
+## Components
 
-An instance consists of the following components: 
+An instance consists of the following components:
 
 - **Image**: Virtual disk that contains the operating system of an instance
 - **Flavor**: Virtual hardware performance specifications of an instance
@@ -16,7 +16,7 @@ An instance consists of the following components:
 
 Instance properties and usage change depending on these components. While settings for these components, with the exception of image and availability zone, can be modified after the creation of an instance, some flavors cannot be modified after an instance has been created. For more details on modifying instance flavors, see [Modify Flavor in the Console Guide](./console-guide/#modify-flavor).
 
-### Image 
+### Image
 
 An image is a virtual disk that contains an operating system. NHN Cloud currently supports CentOS, Debian, Ubuntu, Rocky, and Windows. For more details on the supported operating system versions, see [NHN Cloud Service Introduction](https://toast.com/service/compute/instance).
 
@@ -35,7 +35,7 @@ NHN Cloud provides various instance flavors to support a wide range of use cases
 | u2 | The cheapest instance. Recommended for servers with low workloads. <br />This flavor utilizes local disks, which makes it a less stable but more affordable option compared to other flavors. <br />Instances of this flavor do not guarantee I/O performance. |
 | x1 | A flavor that supports high-end CPU and memory. Recommended for services or applications that require high performance. |
 
-### Availability Zone 
+### Availability Zone
 
 NHN Cloud has divided the entire system into multiple availability zones to prepare for potential failures caused by physical hardware issues. Each availability zone has its own storage system, network switch, data center space, and power supply units. A failure that occurs within one availability zone does not affect other zones, thereby increasing the availability of the whole service. You can ensure increased service availability by creating instances across multiple availability zones.
 
@@ -46,7 +46,7 @@ The following properties hold across different availability zones.
 - Floating IP can be shared across different availability zones. If one availability zone experiences a failure, floating IP can quickly be relocated to another availability zone in order to minimize downtime.
 
 
-### Key Pair 
+### Key Pair
 
 A key pair is a pair of [PKI](https://en.wikipedia.org/wiki/Public_key_infrastructure)-based public and private SSH keys. To access an instance created in NHN Cloud, a key pair is required instead of keyboard-inputted ID/PW authentication which is vulnerable to security attacks. You can safely access an instance once you have been authenticated after sending the instance your login information encoded by your key pair's private key. For more details on how to access instances using key pairs, see [How to Access Instances](#how-to-access-instances).
 
@@ -55,16 +55,16 @@ Key pairs can be newly generated from the NHN Cloud console during instance crea
 > [Caution]
 > When a key pair is newly generated, its private key is downloaded. As private keys are issued only once, be sure to store downloaded private keys in a safe disk or USB drive. If a private key is exposed, anyone can access the instance using the exposed private key, so it must be managed carefully.
 
-### Security Group 
+### Security Group
 
-A security group is a virtual firewall that determines network traffic delivered to an instance. For more details on security groups, see [VPC Overview](/Network/VPC/en/overview/). 
+A security group is a virtual firewall that determines network traffic delivered to an instance. For more details on security groups, see [VPC Overview](/Network/VPC/en/overview/).
 
 > [Note]
 > The default security group is configured to ignore all inbound network traffic. Before accessing an instance using SSH, configure the instance's security group to allow access to the SSH port.
 
-### Network 
+### Network
 
-An instance must be connected to at least one network defined in the VPC in order to communicate externally. An instance that is not connected to a network cannot be accessed. To create or modify networks, see [VPC Overview](/Network/VPC/en/overview/). 
+An instance must be connected to at least one network defined in the VPC in order to communicate externally. An instance that is not connected to a network cannot be accessed. To create or modify networks, see [VPC Overview](/Network/VPC/en/overview/).
 
 ## Pricing
 
@@ -75,9 +75,9 @@ Instances are charged using the following criteria.
 * Stopped instances are charged only for their default disk and additional block storage (if any block storage has been added).
 
 
-## How to Access Instances 
+## How to Access Instances
 
-### How to Access Linux Instances 
+### How to Access Linux Instances
 
 You can access your Linux instances using an SSH client. An instance cannot be accessed if its security group does not have SSH ports (22 by default) allowed. See [VPC Overview](/Network/VPC/en/overview/) for more details on how to allow SSH access. If a floating IP is not assigned to an instance, the instance cannot be accessed from outside NHN Cloud. See [VPC Overview](/Network/VPC/en/overview/) for more details on how to assign floating IP.
 
@@ -151,7 +151,7 @@ When you run pageant, which is installed along with PuTTY, the icon shown below 
 
 ![이미지4](http://static.toastoven.net/prod_instance/putty006.png)
 
-To confirm that your private key has been added, select **View Keys**. If successful, the added key is displayed as below. 
+To confirm that your private key has been added, select **View Keys**. If successful, the added key is displayed as below.
 
 ![이미지5](http://static.toastoven.net/prod_instance/putty008-en.png)
 
@@ -159,7 +159,7 @@ Once you run pageant, it remains running in the Windows tray, so there is no nee
 
 ##### 3. Access Instances With PuTTY
 
-Now that the PuTTY-compatible private key has been successfully registered, run PuTTY. 
+Now that the PuTTY-compatible private key has been successfully registered, run PuTTY.
 
 ![이미지6](http://static.toastoven.net/prod_instance/putty009-en.png)
 
@@ -181,7 +181,7 @@ Rocky
 
 	rocky@<Instance IP>
 
-Select 22, the default SSH port, for the **Port**, and **SSH** for the **Connection type**. 
+Select 22, the default SSH port, for the **Port**, and **SSH** for the **Connection type**.
 
 If all of the information is correct, save the session. Under **Load, save or delete a stored session**, enter the name of the session to save in **Saved Sessions** and click **Save** to save the session. If you do not save the session, your private key settings registered in 2-A are also not preserved.
 

--- a/en/public-api.md
+++ b/en/public-api.md
@@ -39,9 +39,9 @@ This API does not require a request body.
 | flavors.links | Body | Object | Instance flavor path object |
 | flavors.name | Body | String | Instance flavor name |
 
+
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {
@@ -121,7 +121,6 @@ This API does not require a request body.
 
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {
@@ -213,7 +212,6 @@ This API does not require a request body.
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
     "availabilityZoneInfo": [
@@ -267,7 +265,6 @@ This API does not require a request body.
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
   "keypairs": [
@@ -320,7 +317,6 @@ This API does not require a request body.
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
   "keypair": {
@@ -362,7 +358,6 @@ X-Auth-Token: {tokenId}
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
     "keypair": {
@@ -388,7 +383,6 @@ X-Auth-Token: {tokenId}
 
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {
@@ -485,7 +479,6 @@ This API does not require a request body.
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
   "servers": [
@@ -566,7 +559,6 @@ The request format is the same as List Instances.
 
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {
@@ -724,7 +716,6 @@ This API does not require a request body.
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
   "server": {
@@ -876,7 +867,6 @@ X-Auth-Token: {tokenId}
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
   "server": {
@@ -919,7 +909,6 @@ X-Auth-Token: {tokenId}
 
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {
@@ -970,7 +959,6 @@ X-Auth-Token: {tokenId}
 
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {
@@ -1041,7 +1029,6 @@ This API does not require a request body.
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
     "volumeAttachments": [
@@ -1095,7 +1082,6 @@ This API does not require a request body.
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
     "volumeAttachment": {
@@ -1131,7 +1117,6 @@ X-Auth-Token: {tokenId}
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
   "volumeAttachment": {
@@ -1155,7 +1140,6 @@ X-Auth-Token: {tokenId}
 
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {
@@ -1222,7 +1206,6 @@ X-Auth-Token: {tokenId}
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
   "os-start" : null
@@ -1256,7 +1239,6 @@ X-Auth-Token: {tokenId}
 
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {
@@ -1303,7 +1285,6 @@ X-Auth-Token: {tokenId}
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
   "reboot" : {
@@ -1344,7 +1325,6 @@ X-Auth-Token: {tokenId}
 
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {
@@ -1387,7 +1367,6 @@ X-Auth-Token: {tokenId}
 
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {
@@ -1435,7 +1414,6 @@ X-Auth-Token: {tokenId}
 <details><summary>Example</summary>
 <p>
 
-
 ```json
 {
     "addSecurityGroup": {
@@ -1473,7 +1451,6 @@ X-Auth-Token: {tokenId}
 
 <details><summary>Example</summary>
 <p>
-
 
 ```json
 {

--- a/en/public-api.md
+++ b/en/public-api.md
@@ -21,7 +21,7 @@ X-Auth-Token: {tokenId}
 
 #### Request
 
-This API does not require a request body. 
+This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
 |---|---|---|---|---|
@@ -83,14 +83,14 @@ This API does not require a request body.
 
 ---
 
-### List Flavors with Details 
+### List Flavors with Details
 
 ```
 GET /v2/{tenantId}/flavors/detail
 X-Auth-Token: {tokenId}
 ```
 
-#### Request	
+#### Request
 
 This API does not require a request body.
 
@@ -194,7 +194,7 @@ X-Auth-Token: {tokenId}
 ```
 
 #### Request
-This API does not require a request body. 
+This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
 |---|---|---|---|---|
@@ -245,7 +245,7 @@ X-Auth-Token: {tokenId}
 ```
 
 #### Request
-This API does not require a request body. 
+This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
 |---|---|---|---|---|
@@ -291,7 +291,7 @@ X-Auth-Token: {tokenId}
 ```
 
 #### Request
-This API does not require a request body. 
+This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
 |---|---|---|---|---|
@@ -299,7 +299,7 @@ This API does not require a request body.
 | keypairName | URL | String | O | Key pair Name |
 | tokenId | Header | String | O | Token ID |
 
-#### Response	
+#### Response
 
 | Name | Type | Format | Description |
 |---|---|---|---|
@@ -345,7 +345,7 @@ POST /v2/{tenantId}/os-keypairs
 X-Auth-Token: {tokenId}
 ```
 
-#### Request		
+#### Request
 
 | Name | Type | Format | Required | Description |
 |---|---|---|---|---|
@@ -416,7 +416,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 
 #### Response
-This API does not return a response body. 
+This API does not return a response body.
 
 
 ## Instance
@@ -452,7 +452,7 @@ X-Auth-Token: {tokenId}
 
 #### Request
 
-This API does not require a request body. 
+This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
 |---|---|---|---|---|
@@ -505,9 +505,9 @@ This API does not require a request body.
 
 ---
 
-### List Instances with Details 
+### List Instances with Details
 
-Return the list of instances created in the current tenant, same as List Instances. However, detailed instance information is returned. 
+Return the list of instances created in the current tenant, same as List Instances. However, detailed instance information is returned.
 
 ```
 GET /v2/{tenantId}/servers/detail
@@ -516,7 +516,7 @@ X-Auth-Token: {tokenId}
 
 #### Request
 
-The request format is the same as List Instances. 
+The request format is the same as List Instances.
 
 #### Response
 
@@ -665,7 +665,7 @@ X-Auth-Token: {tokenId}
 
 #### Request
 
-This API does not require a request body. 
+This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
 |---|---|---|---|---|
@@ -816,12 +816,12 @@ Create an instance.
 
 After calling the Create Instance API, query the instance and check its status.
 
-* If the status becomes **ACTIVE**, the instance has been created successfully. 
-* If the status remains in **BUILDING** for a long time or becomes **ERROR**, check parameters used for instance creation and try creating again. 
+* If the status becomes **ACTIVE**, the instance has been created successfully.
+* If the status remains in **BUILDING** for a long time or becomes **ERROR**, check parameters used for instance creation and try creating again.
 
 Windows instances have the following additional restrictions that apply to facilitate stable usage.
 
-* Use an instance flavor with at least 2GB RAM capacity.  
+* Use an instance flavor with at least 2GB RAM capacity.
 * Default disk size must be at least 50GB.
 * U2 flavor instances cannot use Windows images.
 
@@ -939,7 +939,7 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### Modify Instance 
+### Modify Instance
 Modify created instance. Only some attributes are allowed to be modified.
 
 ```
@@ -976,8 +976,8 @@ Same as Get Instance.
 
 ---
 
-### Delete Instance 
-Delete a created instance. 
+### Delete Instance
+Delete a created instance.
 
 ```
 DELETE /v2/{tenantId}/servers/{serverId}
@@ -985,7 +985,7 @@ X-Auth-Token: {tokenId}
 ```
 
 #### Request
-This API does not require a request body. 
+This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
 |---|---|---|---|--|
@@ -994,7 +994,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 
 #### Response
-This API does not return a response body. 
+This API does not return a response body.
 
 ---
 
@@ -1060,7 +1060,7 @@ X-Auth-Token: {tokenId}
 ```
 
 #### Request
-This API does not require a request body. 
+This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
 |---|---|---|---|--|
@@ -1098,7 +1098,7 @@ This API does not require a request body.
 
 ---
 
-### Attach Additional Volumes to Instance 
+### Attach Additional Volumes to Instance
 ```
 POST /v2/{tenantId}/servers/{serverId}/os-volume_attachments
 X-Auth-Token: {tokenId}
@@ -1164,7 +1164,7 @@ X-Auth-Token: {tokenId}
 ```
 
 #### Request
-This API does not require a request body. 
+This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
 |---|---|---|---|--|
@@ -1174,17 +1174,17 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 
 #### Response
-This API does not return a response body. 
+This API does not return a response body.
 
 ---
 
-## Additional Instance Features 
+## Additional Instance Features
 NHN Cloud provides the following additional features to handle instances.
 
 * Start, Stop, and Restart Instance
 * Change Instance Flavor
 * Create Instance Image
-* Add/Delete Security Group 
+* Add/Delete Security Group
 
 ### Start Instance
 
@@ -1218,11 +1218,11 @@ X-Auth-Token: {tokenId}
 ---
 
 #### Response
-This API does not return a response body.  
+This API does not return a response body.
 
 ### Stop Instance
 
-Stop instance and change its status to **SHUTOFF**. To call this API, the instance status must be either **ACTIVE** or **ERROR**. 
+Stop instance and change its status to **SHUTOFF**. To call this API, the instance status must be either **ACTIVE** or **ERROR**.
 
 ```
 POST /v2/{tenantId}/servers/{serverId}/action
@@ -1250,7 +1250,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 #### Response
-This API does not return a response body. 
+This API does not return a response body.
 
 ---
 
@@ -1297,7 +1297,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 #### Response
-This API does not return a response body. 
+This API does not return a response body.
 
 ---
 
@@ -1305,7 +1305,7 @@ This API does not return a response body.
 
 Change the flavor of an instance. Flavors can only be changed when an instance is **ACTIVE** or **SHUTOFF**. If an instance is **ACTIVE**, the instance is stopped and restarted while changing flavors.
 
-Depending on the current image and flavor you are using, you may be restricted from changing to some flavors. For more details, see the Console Guide. 
+Depending on the current image and flavor you are using, you may be restricted from changing to some flavors. For more details, see the Console Guide.
 
 
 ```
@@ -1338,7 +1338,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 #### Response
-This API does not return a response body. 
+This API does not return a response body.
 
 ---
 
@@ -1385,7 +1385,7 @@ X-Auth-Token: {tokenId}
 
 #### Response
 
-This API does not return a response body. Check the `Location` response header for the created image.  
+This API does not return a response body. Check the `Location` response header for the created image.
 
 | Name | Type | Format | Description |
 |--|--|--|--|
@@ -1427,13 +1427,13 @@ X-Auth-Token: {tokenId}
 
 
 #### Response
-This API does not return a response body. 
+This API does not return a response body.
 
 ---
 
 ### Delete Security Group
 
-Delete a security group from an instance. The specified security group is deleted from all ports of the instance. 
+Delete a security group from an instance. The specified security group is deleted from all ports of the instance.
 
 ```
 POST /v2/{tenantId}/servers/{serverId}/action
@@ -1465,4 +1465,4 @@ X-Auth-Token: {tokenId}
 
 
 #### Response
-This API does not return a response body. 
+This API does not return a response body.

--- a/en/terraform-guide.md
+++ b/en/terraform-guide.md
@@ -49,7 +49,6 @@ NHN Cloud supports resources and data sources listed below among those available
 * **The version of the Terraform used in the examples below is 1.0.0.**
 * **The name and number of the components including the version can be changed, so make sure you check the information before use.**
 
-
 ## Terraform Installation 
 Go to [Download Terraform](https://www.terraform.io/downloads.html) and download the file suitable for the operating system of your local PC. Decompress the file to an appropriate path and add the path to your environment setting, and the installation is complete.  
 
@@ -610,7 +609,6 @@ resource "openstack_blockstorage_volume_v2" "volume_03" {
 You can import a block storage created on console or via API to Terraform and manage the block storage.
 
 On the `.tf` file, write the information of block storage to import. 
-
 ```
 resource "openstack_blockstorage_volume_v2" "volume_06" {
   name = "volume_06"

--- a/en/terraform-guide.md
+++ b/en/terraform-guide.md
@@ -1,8 +1,8 @@
-## Third Party User Guide > Terraform User Guide 
-This document describes how to use NHN Cloud with Terraform. 
+## Third Party User Guide > Terraform User Guide
+This document describes how to use NHN Cloud with Terraform.
 
 ## Terraform
-Terraform is an open-source tool that lets you easily build and safely change infrastructure, and also efficiently manage configuration of infrastructure. The main features of Terraform are as follows:  
+Terraform is an open-source tool that lets you easily build and safely change infrastructure, and also efficiently manage configuration of infrastructure. The main features of Terraform are as follows:
 
 * **Infrastructure as Code**
     * You can increase the productivity and transparency by defining infrastructure as code.
@@ -10,7 +10,7 @@ Terraform is an open-source tool that lets you easily build and safely change in
 * **Execution Plan**
     * By separating change planning and change execution, you can reduce the potential for mistakes when making changes.
 * **Resource Graph**
-    * You can see in advance how minor changes will affect the entire infrastructure. 
+    * You can see in advance how minor changes will affect the entire infrastructure.
     * By creating a dependency graph, you can make a plan based on the graph and see how your infrastructure changes when you apply the plan.
 * **Change Automation**
     * You can automate the process so that infrastructure with the same configuration can be built and changed in multiple locations.
@@ -18,7 +18,7 @@ Terraform is an open-source tool that lets you easily build and safely change in
 
 NHN Cloud supports resources and data sources listed below among those available in Terraform OpenStack Provider. For more details regarding Terraform OpenStack Provider and features supported by Terraform, see [OpenStack Provider in Terraform website](https://www.terraform.io/docs/providers/openstack/index.html)
 
-#### Supported Resources 
+#### Supported Resources
 
 * Compute
     * openstack_compute_instance_v2
@@ -35,7 +35,7 @@ NHN Cloud supports resources and data sources listed below among those available
 * Storage
     * openstack_blockstorage_volume_v2
 
-#### Supported Data Sources 
+#### Supported Data Sources
 
 * openstack_images_image_v2
 * openstack_blockstorage_volume_v2
@@ -49,8 +49,8 @@ NHN Cloud supports resources and data sources listed below among those available
 * **The version of the Terraform used in the examples below is 1.0.0.**
 * **The name and number of the components including the version can be changed, so make sure you check the information before use.**
 
-## Terraform Installation 
-Go to [Download Terraform](https://www.terraform.io/downloads.html) and download the file suitable for the operating system of your local PC. Decompress the file to an appropriate path and add the path to your environment setting, and the installation is complete.  
+## Terraform Installation
+Go to [Download Terraform](https://www.terraform.io/downloads.html) and download the file suitable for the operating system of your local PC. Decompress the file to an appropriate path and add the path to your environment setting, and the installation is complete.
 
 See the following example for installation.
 
@@ -63,8 +63,8 @@ Terraform v1.0.0
 ```
 
 
-## Terraform Initialization 
-Before using Terraform, create a provider configuration file like below. 
+## Terraform Initialization
+Before using Terraform, create a provider configuration file like below.
 
 The name of the provider file can be set randomly. This example uses `provider.tf` as the filename.
 
@@ -90,20 +90,20 @@ provider "openstack" {
 }
 ```
 * **user_name**
-    * Use the NHN Cloud ID. 
+    * Use the NHN Cloud ID.
 * **tenant_id**
     * From **Compute > Instance > Management** on NHN Cloud console, click **Set API Endpoint** to check the Tenant ID.
 * **password**
     * Use **API Password** that you saved in **Set API Endpoint**.
     * Regarding how to set API passwords, see **User Guide > Compute > Instance > API Preparations**.
 * **auth_url**
-    * Specify the address of the NHN Cloud identification service.  
-    * From **Compute > Instance > Management** on NHN Cloud console, click **Set API Endpoint** to check Identity URL.  
+    * Specify the address of the NHN Cloud identification service.
+    * From **Compute > Instance > Management** on NHN Cloud console, click **Set API Endpoint** to check Identity URL.
 * **region**
     * Enter the region to manage NHN Cloud resources.
-    * **KR1**: Korea (Pangyo) Region 
-    * **KR2**: Korea (Pyeongchon) Region 
-    * **JP1**: Japan (Tokyo) Region 
+    * **KR1**: Korea (Pangyo) Region
+    * **KR2**: Korea (Pyeongchon) Region
+    * **JP1**: Japan (Tokyo) Region
 
 On the path where the provider configuration file is located, use the `init` command to initialize Terraform.
 
@@ -113,12 +113,12 @@ provider.tf
 $ terraform init
 ```
 
-## Terraform Usage 
+## Terraform Usage
 
-Building infrastructure with Terraform has the following life cycle: 
+Building infrastructure with Terraform has the following life cycle:
 
 1. Create tf Files
-2. Check the Execution plan 
+2. Check the Execution plan
 3. Create Resources
 4. Modify Resources
 5. Delete Resources
@@ -129,17 +129,17 @@ First, write the configuration of infrastructure to build on a tf file. To check
 $ terraform plan
 ```
 
-If the execution plan is confirmed, use the `apply` command to create, modify, or delete resources. 
+If the execution plan is confirmed, use the `apply` command to create, modify, or delete resources.
 
 ```
 $ terraform apply
 ```
 
-The following sections describe these steps in more details with examples. 
+The following sections describe these steps in more details with examples.
 
-### Create tf Files 
+### Create tf Files
 
-Create a tf file in the path including the provider configuration file. You can aggregate multiple resource settings in a single tf file, or create separate tf files for each resource. Terraform reads the entire tf files all at once to set up an execution plan.  
+Create a tf file in the path including the provider configuration file. You can aggregate multiple resource settings in a single tf file, or create separate tf files for each resource. Terraform reads the entire tf files all at once to set up an execution plan.
 
 The following example shows an `instance.tf` file that defines a resource creating an instance.
 
@@ -177,11 +177,11 @@ $ terraform plan
 
 If the created plan requires modification, correct tf files and execute the `plan` command again. The `plan` command does not change the actual NHN Cloud resources, so you can check the infrastructure changes without any burden.
 
-### Create Resources 
+### Create Resources
 
-After creating tf files with the plan you need, create resources with the `apply` command. 
+After creating tf files with the plan you need, create resources with the `apply` command.
 
-The following example shows the result of executing the `apply` command using the `instance.tf` file created above.  
+The following example shows the result of executing the `apply` command using the `instance.tf` file created above.
 
 ```
 $ terraform apply
@@ -197,7 +197,7 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 After the `apply` command is executed, Terraform's own database file (terraform.tfstate) that records the history of plan changes is created in the current directory. Be careful not to delete this file.
 
-### Modify Resources 
+### Modify Resources
 
 Open the `.tf` file in which resources to change are defined, modify information, and apply the plan. Specification changes are restricted only to some attributes. If there is a change in an attribute which cannot be changed, the resource is deleted and newly created.
 
@@ -211,7 +211,7 @@ resource "openstack_compute_instance_v2" "terraform-instance-01" {
 }
 ```
 
-Check the execution plan, and the changed security group information is printed out in an organized form. 
+Check the execution plan, and the changed security group information is printed out in an organized form.
 
 ```
 $ terraform plan
@@ -238,7 +238,7 @@ Terraform will perform the following actions:
 Plan: 0 to add, 1 to change, 0 to destroy.
 ```
 
-When you apply the plan, a new security group is added to the instance. 
+When you apply the plan, a new security group is added to the instance.
 ```
 $ terraform apply
 ...
@@ -250,13 +250,13 @@ Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
 
 ### Delete Resources
 
-To delete a resource created with Terraform, delete the corresponding `.tf`  file. 
+To delete a resource created with Terraform, delete the corresponding `.tf`  file.
 
 ```
 $ rm instance.tf
 ```
 
-In the execution plan, you can see that the resources will be deleted. 
+In the execution plan, you can see that the resources will be deleted.
 
 ```
 $ terraform plan
@@ -318,11 +318,11 @@ data "openstack_blockstorage_snapshot_v2" "my_snapshot" {
 For more details on how to use data sources, see `Data Sources` in the [Terraform Website](https://www.terraform.io/docs/providers/openstack/index.html).
 
 
-The following sections describe how to import various resources provided by NHN Cloud by using the data resources feature.  
+The following sections describe how to import various resources provided by NHN Cloud by using the data resources feature.
 
 ### Image
 
-Imports image information. NHN Cloud's public images as well as private images are supported.  
+Imports image information. NHN Cloud's public images as well as private images are supported.
 
 ```
 data "openstack_images_image_v2" "ubuntu_2004_20201222" {
@@ -370,7 +370,7 @@ data "openstack_blockstorage_volume_v2" "volume_00" {
 
 ### Instance Flavor
 
-To check name of a flavor, go to **Compute > Instance** on NHN Cloud console and click **Create Instance > Select Flavor**. 
+To check name of a flavor, go to **Compute > Instance** on NHN Cloud console and click **Create Instance > Select Flavor**.
 
 ```
 data "openstack_compute_flavor_v2" "u2c2m4"{
@@ -404,7 +404,7 @@ data "openstack_blockstorage_snapshot_v2" "my_snapshot" {
 
 ### VPC
 
-To check UUID of VPC network, go to NHN Cloud console and select VPC from **Network > VPC**. 
+To check UUID of VPC network, go to NHN Cloud console and select VPC from **Network > VPC**.
 
 ```
 data "openstack_networking_network_v2" "default_network" {
@@ -421,7 +421,7 @@ data "openstack_networking_network_v2" "default_network" {
 
 ### Subnet
 
-To check subnet ID, go to NHN Cloud console and select a subnet from **Network > VPC > Subnet**. 
+To check subnet ID, go to NHN Cloud console and select a subnet from **Network > VPC > Subnet**.
 
 ```
 data "openstack_networking_subnet_v2" "default_subnet" {
@@ -441,17 +441,17 @@ data "openstack_networking_subnet_v2" "default_subnet" {
 
 You can create, modify, or delete resources with Terraform resources. NHN Cloud supports management of the following resources using Terraform:
 
-* Instance 
+* Instance
 * Block storage
-* Floating IP 
+* Floating IP
 * Network port
 * Load balancer
 
-The following sections describe how to use each resource.  
+The following sections describe how to use each resource.
 
 ## Resources - Instance
 
-### Create Instance 
+### Create Instance
 
 ```
 # Create u2 Instance
@@ -479,8 +479,8 @@ resource "openstack_compute_instance_v2" "tf_instance_01"{
   }
 }
 
-# Flavors other than u2 
-# Create instance with network and block storage added 
+# Flavors other than u2
+# Create instance with network and block storage added
 resource "openstack_compute_instance_v2" "tf_instance_02" {
   name      = "tf_instance_02"
   region    = "KR1"
@@ -551,7 +551,7 @@ resource "openstack_blockstorage_volume_v2" "volume_01" {
   ...
 }
 
-# Attach Block Storage 
+# Attach Block Storage
 resource "openstack_compute_volume_attach_v2" "volume_to_instance"{
   instance_id = openstack_compute_instance_v2.tf_instance_02.id
   volume_id = openstack_blockstorage_volume_v2.volume_01.id
@@ -570,7 +570,7 @@ resource "openstack_compute_volume_attach_v2" "volume_to_instance"{
 
 ### Create Block Storage
 ```
-# Create HDD-type Empty Block Storage 
+# Create HDD-type Empty Block Storage
 resource "openstack_blockstorage_volume_v2" "volume_01" {
   name = "tf_volume_01"
   size = 10
@@ -578,7 +578,7 @@ resource "openstack_blockstorage_volume_v2" "volume_01" {
   volume_type = "General HDD"
 }
 
-# Create SSD-type Empty Block Storage 
+# Create SSD-type Empty Block Storage
 resource "openstack_blockstorage_volume_v2" "volume_02" {
   name = "tf_volume_02"
   size = 10
@@ -586,7 +586,7 @@ resource "openstack_blockstorage_volume_v2" "volume_02" {
   volume_type = "General SSD"
 }
 
-# Create Block Storage with Snapshot 
+# Create Block Storage with Snapshot
 resource "openstack_blockstorage_volume_v2" "volume_03" {
   name = "tf_volume_03"
   description = "terraform create volume with snapshot test"
@@ -608,7 +608,7 @@ resource "openstack_blockstorage_volume_v2" "volume_03" {
 
 You can import a block storage created on console or via API to Terraform and manage the block storage.
 
-On the `.tf` file, write the information of block storage to import. 
+On the `.tf` file, write the information of block storage to import.
 ```
 resource "openstack_blockstorage_volume_v2" "volume_06" {
   name = "volume_06"
@@ -616,7 +616,7 @@ resource "openstack_blockstorage_volume_v2" "volume_06" {
 }
 ```
 
-Import the block storage with the command `terraform import openstack_blockstorage_volume_v2.{name} {block_storage_id}`. 
+Import the block storage with the command `terraform import openstack_blockstorage_volume_v2.{name} {block_storage_id}`.
 
 ```
 $ terraform import openstack_blockstorage_volume_v2.volume_06 10cf5bec-cebb-479b-8408-3ffe3b569a7a
@@ -633,12 +633,12 @@ Import successful!
 
 ## Resources - VPC
 
-NHN Cloud supports creation of the following resources with Terraform: 
+NHN Cloud supports creation of the following resources with Terraform:
 
-* Floating IP 
-* Network port 
+* Floating IP
+* Network port
 
-Other VPC resources must be created on console. 
+Other VPC resources must be created on console.
 
 ### Create Floating IP
 
@@ -705,7 +705,7 @@ resource "openstack_networking_port_v2" "port_1" {
 
 
 
-## Resources - Load Balancer 
+## Resources - Load Balancer
 ### Create Load Balancer
 
 ```
@@ -713,7 +713,7 @@ resource "openstack_lb_loadbalancer_v2" "tf_loadbalancer_01"{
   name = "tf_loadbalancer_01"
   description = "create loadbalancer by terraform."
   vip_subnet_id = data.openstack_networking_subnet_v2.default_subnet.id
-  vip_address = "192.168.0.10"  
+  vip_address = "192.168.0.10"
   admin_state_up = true
 }
 ```
@@ -728,7 +728,7 @@ resource "openstack_lb_loadbalancer_v2" "tf_loadbalancer_01"{
 | admin_state_up | Boolean | - | Administrator control status |
 
 
-### Create Listener 
+### Create Listener
 
 ```
 # HTTP Listener
@@ -814,7 +814,7 @@ resource "openstack_lb_pool_v2" "tf_pool_01"{
 | admin_state_up | Boolean | - | Administrator control status |
 
 
-### Create Health Monitor 
+### Create Health Monitor
 
 ```
 resource "openstack_lb_monitor_v2" "tf_monitor_01"{
@@ -869,5 +869,5 @@ resource "openstack_lb_member_v2" "tf_member_01"{
 | admin_state_up | Boolean | - | Administrator control status |
 
 
-## Reference 
+## Reference
 Terraform Documentation - [https://www.terraform.io/docs/providers/index.html](https://www.terraform.io/docs/providers/index.html)

--- a/en/troubleshooting-guide.md
+++ b/en/troubleshooting-guide.md
@@ -1,17 +1,17 @@
-## Compute > Instance > Troubleshooting Guide 
+## Compute > Instance > Troubleshooting Guide
 
-The document describes how to resolve issues you may encounter while using NHN Cloud. 
+The document describes how to resolve issues you may encounter while using NHN Cloud.
 
 <h3> I want to use a different version, other than the default OS version of NHN Cloud. Can I upload my personal images? </h3>
 
-You can only use the OS version provided by NHN Cloud. And uploading personal images is not allowed. 
-To use personal OS images, create an instance with NHN Cloud image and apply **Create Image**.  
+You can only use the OS version provided by NHN Cloud. And uploading personal images is not allowed.
+To use personal OS images, create an instance with NHN Cloud image and apply **Create Image**.
 <br>
 
 <h3> When I try to access instance, I find "Permissions 0644 for '/Users/username/.ssh/your-key.pem' are too open." and access is not available. </h3>
 
 It happens when the personal key (PEM key) applied to access instance has invalid authority.
-Adjust the authority of personal key file like below. 
+Adjust the authority of personal key file like below.
 
     $ chmod 600 your-key.pem
 
@@ -19,7 +19,7 @@ Adjust the authority of personal key file like below.
 
 <h3> How do I get the root authority from CentOS instance?  </h3>
 
-To get root authority from CentOS instance, use the 'sudo' command like follows. 
+To get root authority from CentOS instance, use the 'sudo' command like follows.
 
     $ sudo su
 
@@ -27,21 +27,21 @@ To get root authority from CentOS instance, use the 'sudo' command like follows.
 
 <h3> I find error mounting, after creating image and instance, and booting it. </h3>
 
-You shall encounter with such error, when an image is created with instance using two or more block storages and instance is created and booted with such image. 
+You shall encounter with such error, when an image is created with instance using two or more block storages and instance is created and booted with such image.
 
 For instances that use more than two block storages, set disks other than default disk in the `/etc/fstab` file. Since the file is to be replicated as well, when image is created, error occurs in mounting due to lack of a block storage referenced by the`/etc/fstab` file.
 
-To resolve this issue, set block storage of the `/etc/fstab` file, except default disk, as footnote, before creating an image. 
+To resolve this issue, set block storage of the `/etc/fstab` file, except default disk, as footnote, before creating an image.
 <br>
 
 <h3> It takes too long to access SSH. </h3>
 
-It happens when DNS is blocked at the receiving part of the security group to which instance belongs. Adjust the security group to be allowed to receive DNS. 
+It happens when DNS is blocked at the receiving part of the security group to which instance belongs. Adjust the security group to be allowed to receive DNS.
 <br>
 
 <h3> I find "Could not resolve the host" and cannot use yum. </h3>
 
-It happens when DNS is blocked at the receiving part of the security group to which instance belongs. Adjust the security group to be allowed to receive DNS. 
+It happens when DNS is blocked at the receiving part of the security group to which instance belongs. Adjust the security group to be allowed to receive DNS.
 <br>
 
 <h3> Package update fails on CentOS 6.x instance. </h3>


### PR DESCRIPTION
- Component Guide: Fix inconsistency with the Korean version
- Overview and Console Guide: Remove redundant HTML comments
- All: Sync the newline status with the Korean version and remove redundant trailing spaces